### PR TITLE
feat: Add linux force reload

### DIFF
--- a/docs/OPTIONS.md
+++ b/docs/OPTIONS.md
@@ -25,6 +25,13 @@
 - description: Path of ssh keys to use as identities in age decryption
 
 
+**`secrets.enableForceReload`**
+
+- type: `types.bool`
+- default: `false`
+- description: For linux, force reload systemd service on home-manager activation
+
+
 **`secrets.file`**
 
 - type: `types.attrsOf secretType`

--- a/module/darwin.nix
+++ b/module/darwin.nix
@@ -1,0 +1,8 @@
+{ config, pkgs, lib, ... }:
+{ script }:
+
+{
+  home.activation = {
+    homeManagerSecrets = lib.hm.dag.entryAfter [ "writeBoundary" ] script;
+  };
+}

--- a/module/default.nix
+++ b/module/default.nix
@@ -101,6 +101,12 @@ in
       description = "Path of ssh keys to use as identities in age decryption";
     };
 
+    enableForceReload = mkOption {
+      type = types.bool;
+      default = false;
+      description = "For linux, force reload systemd service on home-manager activation";
+    };
+
     file = mkOption {
       type = types.attrsOf secretType;
       default = { };

--- a/module/linux.nix
+++ b/module/linux.nix
@@ -2,6 +2,8 @@
 { script }:
 
 let
+  cfg = config.secrets;
+
   scriptBin = pkgs.writeShellScriptBin "home-manager-secrets-script" ''
     set -euo pipefail
     DRY_RUN_CMD=
@@ -26,7 +28,7 @@ in
     };
   };
 
-  home.activation = {
+  home.activation = lib.mkIf cfg.enableForceReload {
     homeManagerSecrets = lib.hm.dag.entryAfter [ "reloadSystemd" ] ''
       (
         export XDG_RUNTIME_DIR=''${XDG_RUNTIME_DIR:-/run/user/$(id -u)}

--- a/module/linux.nix
+++ b/module/linux.nix
@@ -25,4 +25,16 @@ in
       };
     };
   };
+
+  home.activation = {
+    homeManagerSecrets = lib.hm.dag.entryAfter [ "reloadSystemd" ] ''
+      (
+        export XDG_RUNTIME_DIR=''${XDG_RUNTIME_DIR:-/run/user/$(id -u)}
+
+        if systemctl --user list-units --full --no-legend -all | grep "home-manager-secrets.service"; then
+          systemctl --user restart home-manager-secrets.service
+        fi
+      )
+    '';
+  };
 }

--- a/module/linux.nix
+++ b/module/linux.nix
@@ -1,0 +1,28 @@
+{ config, pkgs, lib, ... }:
+{ script }:
+
+let
+  scriptBin = pkgs.writeShellScriptBin "home-manager-secrets-script" ''
+    set -euo pipefail
+    DRY_RUN_CMD=
+    VERBOSE_ARG=
+    ${script}
+  '';
+
+in
+{
+  systemd.user.services = {
+    "home-manager-secrets" = {
+      Unit = {
+        Description = "Decrypt home-manager-secrets files";
+      };
+      Install = {
+        WantedBy = [ "default.target" ];
+      };
+      Service = {
+        ExecStart = "${scriptBin}/bin/home-manager-secrets-script";
+        Environment = "PATH=${lib.makeBinPath [ pkgs.coreutils ]}";
+      };
+    };
+  };
+}


### PR DESCRIPTION
- When using home-manager as a NixOS module, home-manager-secrets service does not automatically restart well
- Add a option (`secrets.enableForceReload`) to manually restarst the service on home-manager activation
